### PR TITLE
Add GitHub Skills activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills through GitHub. Part of our GitHub Certifications program to help with college applications.",
+        "schedule": "Mondays and Thursdays, 3:00 PM - 4:30 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🚀 Add GitHub Skills Activity

This PR resolves issue #6 by adding the missing GitHub Skills activity that was announced by the principal.

### ✅ Changes Made
- Added "GitHub Skills" to the activities dictionary in `src/app.py`
- Set schedule: Mondays and Thursdays, 3:00 PM - 4:30 PM
- Set capacity: 25 participants (generous for a popular new program)
- Added descriptive text mentioning the GitHub Certifications program and college application benefits
- Started with empty participants list, ready for student registrations

### 🎯 Key Features
- **Time-sensitive**: Addresses the urgent need for registrations before week end
- **Educational value**: Part of GitHub Certifications program
- **Future-ready**: Helps with college applications
- **Partnership opportunity**: Supports the new GitHub collaboration

### 🧪 Testing
- ✅ Syntax validation passed
- ✅ API endpoint returns the new activity
- ✅ Student registration works correctly
- ✅ All existing functionality preserved

Ready for students to start registering! 🎓

Closes #6